### PR TITLE
Added persistent default country and switch between global and country

### DIFF
--- a/lib/settingsDialog.dart
+++ b/lib/settingsDialog.dart
@@ -1,19 +1,23 @@
-import 'package:covid19stats/main.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class Settings {
   bool defaultDailyView = false;
   bool alwaysLoadCharts = false;
+  bool defaultCountryView = false;
   bool loaded = false;
 
-  Settings({this.alwaysLoadCharts, this.defaultDailyView, this.loaded});
+  Settings(
+      {this.alwaysLoadCharts,
+      this.defaultDailyView,
+      this.defaultCountryView,
+      this.loaded});
 
   Future<void> load() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     this.alwaysLoadCharts = prefs.getBool('alwaysLoadCharts') ?? false;
     this.defaultDailyView = prefs.getBool('defaultDailyView') ?? false;
+    this.defaultCountryView = prefs.getBool('defaultCountryView') ?? false;
     this.loaded = true;
   }
 
@@ -21,21 +25,26 @@ class Settings {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     prefs.setBool('alwaysLoadCharts', this.alwaysLoadCharts);
     prefs.setBool('defaultDailyView', this.defaultDailyView);
+    prefs.setBool('defaultCountryView', this.defaultCountryView);
     return true;
   }
 
   Settings clone() {
     return new Settings(
-      alwaysLoadCharts: this.alwaysLoadCharts,
-      defaultDailyView: this.defaultDailyView,
-      loaded: true
-    );
+        alwaysLoadCharts: this.alwaysLoadCharts,
+        defaultDailyView: this.defaultDailyView,
+        defaultCountryView: this.defaultCountryView,
+        loaded: true);
   }
 
   dynamic operator [](String key) {
-    switch(key) {
-      case 'alwaysLoadCharts': return this.alwaysLoadCharts;
-      case 'defaultDailyView': return this.defaultDailyView;
+    switch (key) {
+      case 'alwaysLoadCharts':
+        return this.alwaysLoadCharts;
+      case 'defaultDailyView':
+        return this.defaultDailyView;
+      case 'defaultCountryView':
+        return this.defaultCountryView;
     }
   }
 }
@@ -65,8 +74,17 @@ class _SettingsDialogState extends State<SettingsDialog> {
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         mainAxisSize: MainAxisSize.min,
         children: [
-          getSwitchRow("Always load charts", newSettings.alwaysLoadCharts, (v){newSettings.alwaysLoadCharts = v;}),
-          getSwitchRow("Default to daily view", newSettings.defaultDailyView, (v){newSettings.defaultDailyView = v;}),
+          getSwitchRow("Always load charts", newSettings.alwaysLoadCharts, (v) {
+            newSettings.alwaysLoadCharts = v;
+          }),
+          getSwitchRow("Default to daily view", newSettings.defaultDailyView,
+              (v) {
+            newSettings.defaultDailyView = v;
+          }),
+          getSwitchRow(
+              "Default to country view", newSettings.defaultCountryView, (v) {
+            newSettings.defaultCountryView = v;
+          }),
         ],
       ),
       actions: <Widget>[
@@ -96,7 +114,9 @@ class _SettingsDialogState extends State<SettingsDialog> {
         Switch(
           value: value,
           onChanged: (newValue) {
-            setState(() {setValue(newValue);});
+            setState(() {
+              setValue(newValue);
+            });
           },
           activeTrackColor: Colors.red[300],
           activeColor: Colors.red,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   ffi:
     dependency: transitive
     description:
@@ -134,21 +134,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   path_drawing:
     dependency: transitive
     description:
@@ -265,56 +265,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
   win32:
     dependency: transitive
     description:
@@ -330,5 +330,5 @@ packages:
     source: hosted
     version: "0.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"


### PR DESCRIPTION
#7 
>it would be nice to add the ability to set a persistent default country, which perhaps also loads the charts by default.
  - Added the "Default to country view" in settingsDialog.dart
  - Now, user can select their country and it will show that country's stats if the "Default to country view" is true.

 > if a default country is chosen, a simple button in the top bar to quickly switch between the default country and the global stats may be interesting
   - They can do that by toggling "Default to country view"  in settings
